### PR TITLE
feat: add shop page with product catalog and cart

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,7 +6,8 @@ const navItems = [
     { linkText: 'Revalidation', href: '/revalidation' },
     { linkText: 'Image CDN', href: '/image-cdn' },
     { linkText: 'Edge Function', href: '/edge' },
-    { linkText: 'Blobs', href: '/blobs' }
+    { linkText: 'Blobs', href: '/blobs' },
+    { linkText: 'Shop', href: '/shop' }
 ];
 ---
 

--- a/src/pages/api/product.ts
+++ b/src/pages/api/product.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from 'astro';
+import { getStore } from '@netlify/blobs';
+
+export const prerender = false;
+
+export const GET: APIRoute = async (context) => {
+    const key = new URL(context.url).searchParams.get('key');
+    if (!key) {
+        return new Response('Bad Request', { status: 400 });
+    }
+    const store = getStore('products');
+    const product = await store.get(key, { type: 'json' });
+    return new Response(JSON.stringify({ product }));
+};

--- a/src/pages/api/products.ts
+++ b/src/pages/api/products.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from 'astro';
+import { getStore } from '@netlify/blobs';
+import type { ProductProps } from '../../types';
+
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+    try {
+        const store = getStore({ name: 'products', consistency: 'strong' });
+        const { blobs } = await store.list();
+        const products = await Promise.all(blobs.map(({ key }) => store.get(key, { type: 'json' }) as Promise<ProductProps>));
+        return new Response(JSON.stringify({ products }));
+    } catch (e) {
+        console.error(e);
+        return new Response(JSON.stringify({ products: [], error: 'Failed listing products' }));
+    }
+};
+
+export const POST: APIRoute = async ({ request }) => {
+    const product: ProductProps = await request.json();
+    const store = getStore('products');
+    await store.setJSON(product.id, product);
+    return new Response(JSON.stringify({ message: `Saved product "${product.name}"` }));
+};

--- a/src/pages/shop/_components/Cart.tsx
+++ b/src/pages/shop/_components/Cart.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import type { CartItem } from '../../../types';
+
+interface Props {
+    items: CartItem[];
+    onUpdateQty: (id: string, qty: number) => void;
+    onRemove: (id: string) => void;
+    onClose: () => void;
+    onCheckout: (name: string, email: string) => void;
+    orderPlaced: boolean;
+}
+
+export default function Cart({ items, onUpdateQty, onRemove, onClose, onCheckout, orderPlaced }: Props) {
+    const [name, setName] = useState('');
+    const [email, setEmail] = useState('');
+
+    const subtotal = items.reduce((sum, item) => sum + item.product.price * item.quantity, 0);
+    const dollars = (cents: number) => (cents / 100).toFixed(2);
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (name.trim() && email.trim()) {
+            onCheckout(name, email);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex justify-end">
+            {/* Backdrop */}
+            <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+
+            {/* Panel */}
+            <div className="relative flex flex-col w-full max-w-md bg-white shadow-xl h-full overflow-y-auto">
+                <div className="flex items-center justify-between p-4 border-b border-gray-200">
+                    <h2 className="text-gray-900 text-xl font-bold">Your Cart</h2>
+                    <button onClick={onClose} className="text-gray-500 hover:text-gray-900 transition text-2xl leading-none" aria-label="Close cart">
+                        ×
+                    </button>
+                </div>
+
+                {orderPlaced ? (
+                    <div className="flex flex-col items-center justify-center flex-1 gap-4 p-8 text-center">
+                        <div className="text-6xl">🎉</div>
+                        <h3 className="text-gray-900 text-2xl font-bold">Order placed!</h3>
+                        <p className="text-gray-500">Thanks, {name}! We'll send a confirmation to {email}.</p>
+                        <button className="btn btn-lg mt-4" onClick={onClose}>
+                            Continue shopping
+                        </button>
+                    </div>
+                ) : (
+                    <>
+                        {items.length === 0 ? (
+                            <div className="flex flex-col items-center justify-center flex-1 gap-3 p-8 text-center">
+                                <div className="text-5xl">🛒</div>
+                                <p className="text-gray-500">Your cart is empty.</p>
+                            </div>
+                        ) : (
+                            <>
+                                <ul className="flex-1 divide-y divide-gray-100">
+                                    {items.map(({ product, quantity }) => (
+                                        <li key={product.id} className="flex items-start gap-3 p-4">
+                                            <span className="text-3xl">{product.emoji}</span>
+                                            <div className="flex-1 min-w-0">
+                                                <p className="text-gray-900 font-medium text-sm truncate">{product.name}</p>
+                                                <p className="text-gray-500 text-sm">${dollars(product.price)} each</p>
+                                                <div className="flex items-center gap-2 mt-2">
+                                                    <button
+                                                        className="w-7 h-7 flex items-center justify-center rounded bg-gray-100 text-gray-700 hover:bg-gray-200 transition text-base font-bold"
+                                                        onClick={() => onUpdateQty(product.id, quantity - 1)}
+                                                        aria-label="Decrease quantity"
+                                                    >
+                                                        −
+                                                    </button>
+                                                    <span className="text-gray-900 text-sm w-5 text-center">{quantity}</span>
+                                                    <button
+                                                        className="w-7 h-7 flex items-center justify-center rounded bg-gray-100 text-gray-700 hover:bg-gray-200 transition text-base font-bold"
+                                                        onClick={() => onUpdateQty(product.id, quantity + 1)}
+                                                        aria-label="Increase quantity"
+                                                    >
+                                                        +
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <div className="text-right">
+                                                <p className="text-gray-900 font-semibold text-sm">${dollars(product.price * quantity)}</p>
+                                                <button className="text-gray-400 hover:text-red-500 transition text-xs mt-1" onClick={() => onRemove(product.id)}>
+                                                    Remove
+                                                </button>
+                                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+
+                                <div className="border-t border-gray-200 p-4">
+                                    <div className="flex justify-between text-gray-900 font-bold text-base mb-4">
+                                        <span>Subtotal</span>
+                                        <span>${dollars(subtotal)}</span>
+                                    </div>
+                                    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+                                        <input
+                                            type="text"
+                                            placeholder="Your name"
+                                            value={name}
+                                            onChange={(e) => setName(e.target.value)}
+                                            required
+                                            className="w-full px-3 py-2 rounded border border-gray-300 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+                                        />
+                                        <input
+                                            type="email"
+                                            placeholder="Email address"
+                                            value={email}
+                                            onChange={(e) => setEmail(e.target.value)}
+                                            required
+                                            className="w-full px-3 py-2 rounded border border-gray-300 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+                                        />
+                                        <button type="submit" className="btn w-full justify-center" style={{ '--btn-py': '0.75rem' } as React.CSSProperties}>
+                                            Place order
+                                        </button>
+                                    </form>
+                                </div>
+                            </>
+                        )}
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/shop/_components/ProductCard.tsx
+++ b/src/pages/shop/_components/ProductCard.tsx
@@ -1,0 +1,33 @@
+import type { ProductProps } from '../../../types';
+
+interface Props {
+    product: ProductProps;
+    onAddToCart: (product: ProductProps) => void;
+}
+
+export default function ProductCard({ product, onAddToCart }: Props) {
+    const dollars = (product.price / 100).toFixed(2);
+
+    return (
+        <div className="flex flex-col bg-white rounded-lg overflow-hidden">
+            <div className="flex items-center justify-center text-6xl bg-gray-50 aspect-square p-6">{product.emoji}</div>
+            <div className="flex flex-col flex-1 p-4 gap-3">
+                <div>
+                    <span className="text-xs font-medium text-complementary/70 uppercase tracking-wide">{product.category}</span>
+                    <h3 className="text-gray-900 font-semibold text-base leading-tight mt-0.5">{product.name}</h3>
+                    <p className="text-gray-500 text-sm mt-1 leading-snug">{product.description}</p>
+                </div>
+                <div className="flex items-center justify-between mt-auto">
+                    <span className="text-gray-900 font-bold text-lg">${dollars}</span>
+                    <button
+                        className="btn"
+                        style={{ '--btn-py': '0.5rem', '--btn-px': '1rem', '--btn-font-size': '0.8125rem' } as React.CSSProperties}
+                        onClick={() => onAddToCart(product)}
+                    >
+                        Add to cart
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/shop/_components/ShopIsland.tsx
+++ b/src/pages/shop/_components/ShopIsland.tsx
@@ -1,0 +1,184 @@
+import { useState, useEffect } from 'react';
+import type { ProductProps, CartItem } from '../../../types';
+import ProductCard from './ProductCard';
+import Cart from './Cart';
+
+const SEED_PRODUCTS: ProductProps[] = [
+    {
+        id: 'wireless-headphones',
+        name: 'Wireless Headphones',
+        description: 'Premium sound quality with active noise cancellation and 30-hour battery life.',
+        price: 4999,
+        emoji: '🎧',
+        category: 'Electronics',
+        inventory: 12
+    },
+    {
+        id: 'javascript-cookbook',
+        name: 'JavaScript Cookbook',
+        description: 'Over 300 recipes for solving real-world JavaScript problems. Updated for ES2024.',
+        price: 2499,
+        emoji: '📚',
+        category: 'Books',
+        inventory: 35
+    },
+    {
+        id: 'pour-over-coffee-set',
+        name: 'Pour-Over Coffee Set',
+        description: 'Handcrafted ceramic dripper with a glass carafe. Brew the perfect cup every morning.',
+        price: 3499,
+        emoji: '☕',
+        category: 'Kitchen',
+        inventory: 8
+    },
+    {
+        id: 'soy-candle-collection',
+        name: 'Soy Candle Collection',
+        description: 'Set of 3 hand-poured soy candles in calming scents: lavender, cedar, and vanilla.',
+        price: 1999,
+        emoji: '🕯️',
+        category: 'Home',
+        inventory: 20
+    },
+    {
+        id: 'logo-cap',
+        name: 'Logo Cap',
+        description: 'Structured six-panel cap with an embroidered logo. One size fits most.',
+        price: 1499,
+        emoji: '🧢',
+        category: 'Apparel',
+        inventory: 50
+    },
+    {
+        id: 'retro-controller',
+        name: 'Retro Controller',
+        description: 'USB-C gamepad with tactile d-pad and bumpers. Compatible with PC, Mac, and mobile.',
+        price: 3999,
+        emoji: '🎮',
+        category: 'Gaming',
+        inventory: 15
+    }
+];
+
+export default function ShopIsland() {
+    const [products, setProducts] = useState<ProductProps[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [cart, setCart] = useState<CartItem[]>([]);
+    const [showCart, setShowCart] = useState(false);
+    const [orderPlaced, setOrderPlaced] = useState(false);
+
+    const fetchProducts = async () => {
+        const res = await fetch('/api/products');
+        const data = await res.json();
+        return (data.products as ProductProps[]) ?? [];
+    };
+
+    const seedProducts = async () => {
+        await Promise.all(
+            SEED_PRODUCTS.map((p) =>
+                fetch('/api/products', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(p)
+                })
+            )
+        );
+    };
+
+    useEffect(() => {
+        (async () => {
+            setLoading(true);
+            let fetched = await fetchProducts();
+            if (fetched.length === 0) {
+                await seedProducts();
+                fetched = await fetchProducts();
+            }
+            setProducts(fetched);
+            setLoading(false);
+        })();
+    }, []);
+
+    const addToCart = (product: ProductProps) => {
+        setCart((prev) => {
+            const existing = prev.find((item) => item.product.id === product.id);
+            if (existing) {
+                return prev.map((item) => (item.product.id === product.id ? { ...item, quantity: item.quantity + 1 } : item));
+            }
+            return [...prev, { product, quantity: 1 }];
+        });
+        setShowCart(true);
+    };
+
+    const updateQty = (id: string, qty: number) => {
+        if (qty <= 0) {
+            removeFromCart(id);
+        } else {
+            setCart((prev) => prev.map((item) => (item.product.id === id ? { ...item, quantity: qty } : item)));
+        }
+    };
+
+    const removeFromCart = (id: string) => {
+        setCart((prev) => prev.filter((item) => item.product.id !== id));
+    };
+
+    const handleCheckout = (_name: string, _email: string) => {
+        setOrderPlaced(true);
+    };
+
+    const handleCloseCart = () => {
+        setShowCart(false);
+        if (orderPlaced) {
+            setCart([]);
+            setOrderPlaced(false);
+        }
+    };
+
+    const cartCount = cart.reduce((sum, item) => sum + item.quantity, 0);
+
+    return (
+        <>
+            {/* Cart button */}
+            <div className="flex justify-end mb-8">
+                <button
+                    className="btn relative"
+                    onClick={() => setShowCart(true)}
+                    style={{ '--btn-py': '0.625rem', '--btn-px': '1.125rem' } as React.CSSProperties}
+                >
+                    🛒 Cart
+                    {cartCount > 0 && (
+                        <span className="absolute -top-2 -right-2 w-5 h-5 flex items-center justify-center rounded-full bg-complementary text-white text-xs font-bold">
+                            {cartCount}
+                        </span>
+                    )}
+                </button>
+            </div>
+
+            {/* Product grid */}
+            {loading ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                        <div key={i} className="bg-white/10 rounded-lg aspect-[3/4] animate-pulse" />
+                    ))}
+                </div>
+            ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                    {products.map((product) => (
+                        <ProductCard key={product.id} product={product} onAddToCart={addToCart} />
+                    ))}
+                </div>
+            )}
+
+            {/* Cart sidebar */}
+            {showCart && (
+                <Cart
+                    items={cart}
+                    onUpdateQty={updateQty}
+                    onRemove={removeFromCart}
+                    onClose={handleCloseCart}
+                    onCheckout={handleCheckout}
+                    orderPlaced={orderPlaced}
+                />
+            )}
+        </>
+    );
+}

--- a/src/pages/shop/index.astro
+++ b/src/pages/shop/index.astro
@@ -1,0 +1,17 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Markdown from '../../components/Markdown.astro';
+import ShopIsland from './_components/ShopIsland';
+
+const explainer = `
+This shop demo uses **[Netlify Blobs](https://docs.netlify.com/blobs/overview/)** as its product catalog storage.
+On first load, six products are seeded into the blob store. The cart is managed as client-side React state —
+click **Add to cart**, adjust quantities, then place an order with your name and email.
+`;
+---
+
+<Layout title="Shop">
+    <h1 class="mb-10">Shop</h1>
+    <Markdown content={explainer} class="mb-12" />
+    <ShopIsland client:load />
+</Layout>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,18 @@
+export type ProductProps = {
+    id: string;
+    name: string;
+    description: string;
+    price: number;
+    emoji: string;
+    category: string;
+    inventory: number;
+};
+
+export type CartItem = {
+    product: ProductProps;
+    quantity: number;
+};
+
 export type BlobParameterProps = {
     seed: number;
     size: number;


### PR DESCRIPTION
Adds a /shop route demonstrating Netlify Blobs as a product data store. Six demo products are auto-seeded into the blob store on first visit. The React island manages cart state client-side (add/remove, qty controls) with an inline name+email checkout form and success confirmation.

- src/types.ts: add ProductProps and CartItem types
- src/pages/api/products.ts: GET (list all) / POST (save) products
- src/pages/api/product.ts: GET single product by key
- src/pages/shop/index.astro: /shop page shell
- src/pages/shop/_components/ShopIsland.tsx: root island with cart state
- src/pages/shop/_components/ProductCard.tsx: product display + add-to-cart
- src/pages/shop/_components/Cart.tsx: cart sidebar with checkout form
- src/components/Header.astro: add Shop nav link

https://claude.ai/code/session_01Amnk7s4CfGzz3aKCRvr26R

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new server endpoints that read/write Netlify Blobs without validation/auth, which could affect data integrity if deployed broadly. Otherwise changes are additive and isolated to the new shop feature.
> 
> **Overview**
> Adds a new **Shop** demo at `/shop`, wired into the header nav, that displays a product grid and a client-side cart/checkout sidebar via a React island.
> 
> Introduces new Blobs-backed API routes (`/api/products` for list/save and `/api/product` for single fetch) plus shared `ProductProps`/`CartItem` types, with first-visit seeding of a small demo catalog into the `products` blob store.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b0b92feeb9201bbfe1bea0b340206a317aae2aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->